### PR TITLE
Define network specific headers

### DIFF
--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -78,7 +78,7 @@ network (network_a), ledger (network), voting (network), node (network), portmap
 	unsigned constexpr kdf_full_work = 64 * 1024;
 	unsigned constexpr kdf_test_work = 8;
 	kdf_work = network.is_test_network () ? kdf_test_work : kdf_full_work;
-	header_magic_number = network.is_test_network () ? std::array<uint8_t, 2>{ { 'M', 'A' } } : network.is_beta_network () ? std::array<uint8_t, 2>{ { 'M', 'B' } } : std::array<uint8_t, 2>{ { 'M', 'C' } };
+	header_magic_number = network.is_test_network () ? std::array<uint8_t, 2>{ { 'M', 'C' } } : network.is_beta_network () ? std::array<uint8_t, 2>{ { 'M', 'B' } } : std::array<uint8_t, 2>{ { 'M', 'A' } };
 }
 
 uint8_t nano::protocol_constants::protocol_version_min (bool use_epoch_2_min_version_a) const


### PR DESCRIPTION
### Network specific headers defined.

Header definitions to avoid the intersection with other networks, Nano itself or other Nano forks.

**Defined headers are:**
Live network: MA
Beta network: MB
Test network: MC