### PR TITLE
Define preconfigured peers

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -725,7 +725,7 @@ TEST (node_config, v15_v16_upgrade)
 	};
 
 	// Check that upgrades work with both
-	test_upgrade ("livenet.meow-coin.cf", "livenet.meow-coin.cf");
+	test_upgrade ("::ffff:89.216.106.116", "::ffff:89.216.106.116");
 	test_upgrade ("betanet.meow-coin.cf", "betanet.meow-coin.cf");
 }
 

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -725,7 +725,7 @@ TEST (node_config, v15_v16_upgrade)
 	};
 
 	// Check that upgrades work with both
-	test_upgrade ("::ffff:89.216.106.116", "::ffff:89.216.106.116");
+	test_upgrade ("livenet.meow-coin.cf", "livenet.meow-coin.cf");
 	test_upgrade ("betanet.meow-coin.cf", "betanet.meow-coin.cf");
 }
 

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -725,8 +725,8 @@ TEST (node_config, v15_v16_upgrade)
 	};
 
 	// Check that upgrades work with both
-	test_upgrade ("rai.raiblocks.net", "peering.nano.org");
-	test_upgrade ("rai-beta.raiblocks.net", "peering-beta.nano.org");
+	test_upgrade ("livenet.meow-coin.cf", "livenet.meow-coin.cf");
+	test_upgrade ("betanet.meow-coin.cf", "betanet.meow-coin.cf");
 }
 
 TEST (node_config, v16_values)

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -15,7 +15,7 @@ namespace
 const char * preconfigured_peers_key = "preconfigured_peers";
 const char * signature_checker_threads_key = "signature_checker_threads";
 const char * pow_sleep_interval_key = "pow_sleep_interval";
-const char * default_beta_peer_network = "betanet.meow-coin-cf";
+const char * default_beta_peer_network = "betanet.meow-coin.cf";
 const char * default_live_peer_network = "livenet.meow-coin.cf";
 }
 

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -15,8 +15,8 @@ namespace
 const char * preconfigured_peers_key = "preconfigured_peers";
 const char * signature_checker_threads_key = "signature_checker_threads";
 const char * pow_sleep_interval_key = "pow_sleep_interval";
-const char * default_beta_peer_network = "betanet.meow-coin-cf";
-const char * default_live_peer_network = "livenet.meow-coin.cf";
+const char * default_beta_peer_network = "betanet.meow-coin.cf";
+const char * default_live_peer_network = "::ffff:89.216.106.116";
 }
 
 nano::node_config::node_config () :
@@ -596,7 +596,7 @@ bool nano::node_config::upgrade_json (unsigned version_a, nano::jsonconfig & jso
 				{
 					entry = default_beta_peer_network;
 				}
-				else if (entry == "livenet.meow-coin.cf")
+				else if (entry == "::ffff:89.216.106.116")
 				{
 					entry = default_live_peer_network;
 				}

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -15,8 +15,8 @@ namespace
 const char * preconfigured_peers_key = "preconfigured_peers";
 const char * signature_checker_threads_key = "signature_checker_threads";
 const char * pow_sleep_interval_key = "pow_sleep_interval";
-const char * default_beta_peer_network = "peering-beta.nano.org";
-const char * default_live_peer_network = "peering.nano.org";
+const char * default_beta_peer_network = "betanet.meow-coin-cf";
+const char * default_live_peer_network = "livenet.meow-coin.cf";
 }
 
 nano::node_config::node_config () :
@@ -592,11 +592,11 @@ bool nano::node_config::upgrade_json (unsigned version_a, nano::jsonconfig & jso
 			auto peers_l (json.get_required_child (preconfigured_peers_key));
 			nano::jsonconfig peers;
 			peers_l.array_entries<std::string> ([&peers](std::string entry) {
-				if (entry == "rai-beta.raiblocks.net")
+				if (entry == "betanet.meow-coin.cf")
 				{
 					entry = default_beta_peer_network;
 				}
-				else if (entry == "rai.raiblocks.net")
+				else if (entry == "livenet.meow-coin.cf")
 				{
 					entry = default_live_peer_network;
 				}

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -15,8 +15,8 @@ namespace
 const char * preconfigured_peers_key = "preconfigured_peers";
 const char * signature_checker_threads_key = "signature_checker_threads";
 const char * pow_sleep_interval_key = "pow_sleep_interval";
-const char * default_beta_peer_network = "betanet.meow-coin.cf";
-const char * default_live_peer_network = "::ffff:89.216.106.116";
+const char * default_beta_peer_network = "betanet.meow-coin-cf";
+const char * default_live_peer_network = "livenet.meow-coin.cf";
 }
 
 nano::node_config::node_config () :
@@ -596,7 +596,7 @@ bool nano::node_config::upgrade_json (unsigned version_a, nano::jsonconfig & jso
 				{
 					entry = default_beta_peer_network;
 				}
-				else if (entry == "::ffff:89.216.106.116")
+				else if (entry == "livenet.meow-coin.cf")
 				{
 					entry = default_live_peer_network;
 				}


### PR DESCRIPTION
### Preconfigured peers defined as DNS record.

Additional peers might be and will be included in the future.

**Defined peers:**
Live network: livenet.meow-coin.cf
Beta network: betanet.meow-coin.fc