### PR TITLE
Define preconfigured representatives

### DIFF
--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -417,7 +417,7 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	peering_port = 999
 	pow_sleep_interval= 999
 	preconfigured_peers = ["test.org"]
-	preconfigured_representatives = ["nano_3arg3asgtigae3xckabaaewkx3bzsh7nwz7jkmjos79ihyaxwphhm6qgjps4"]
+	preconfigured_representatives = ["meow_1meow5tythdoss3xqjjw1y445zc1kazm7fxkfi1umm5uw5w3x3u5jbgi8mca"]
 	receive_minimum = "999"
 	signature_checker_threads = 999
 	tcp_incoming_connections_max = 999

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -45,13 +45,15 @@ external_address (boost::asio::ip::address_v6{}.to_string ())
 		{
 			preconfigured_peers.push_back (default_beta_peer_network);
 			nano::account offline_representative;
-			release_assert (!offline_representative.decode_account ("nano_1defau1t9off1ine9rep99999999999999999999999999999999wgmuzxxy"));
+			release_assert (!offline_representative.decode_account ("meow_1betad3cx1k51r1jaobjszrcw16gqee57oyrnewfd51s846rxkj96darjn81"));
 			preconfigured_representatives.emplace_back (offline_representative);
 			break;
 		}
 		case nano::nano_networks::nano_live_network:
 			preconfigured_peers.push_back (default_live_peer_network);
-			preconfigured_representatives.emplace_back ("A30E0A32ED41C8607AA9212843392E853FCBCB4E7CB194E35C94F07F91DE59EF");
+			// meow_1meow5tythdoss3xqjjw1y445zc1kazm7fxkfi1umm5uw5w3x3u5jbgi8mca
+			preconfigured_representatives.emplace_back ("4D95E0F5ED3D75CE43DBC63C078421FD40923F32B7B26C01B9CC7BE0F81E8763");
+			/*
 			preconfigured_representatives.emplace_back ("67556D31DDFC2A440BF6147501449B4CB9572278D034EE686A6BEE29851681DF");
 			preconfigured_representatives.emplace_back ("5C2FBB148E006A8E8BA7A75DD86C9FE00C83F5FFDBFD76EAA09531071436B6AF");
 			preconfigured_representatives.emplace_back ("AE7AC63990DAAAF2A69BF11C913B928844BF5012355456F2F164166464024B29");
@@ -59,6 +61,7 @@ external_address (boost::asio::ip::address_v6{}.to_string ())
 			preconfigured_representatives.emplace_back ("2399A083C600AA0572F5E36247D978FCFC840405F8D4B6D33161C0066A55F431");
 			preconfigured_representatives.emplace_back ("2298FAB7C61058E77EA554CB93EDEEDA0692CBFCC540AB213B2836B29029E23A");
 			preconfigured_representatives.emplace_back ("3FE80B4BC842E82C1C18ABFEEC47EA989E63953BC82AC411F304D13833D52A56");
+			*/
 			break;
 		default:
 			debug_assert (false);


### PR DESCRIPTION
### Preconfigured representative defined.

The additional representatives will be included in the future.

**Defined representatives:**

Live network:
```bash
meow_1meow5tythdoss3xqjjw1y445zc1kazm7fxkfi1umm5uw5w3x3u5jbgi8mca
```
Beta network:
```bash
meow_1betad3cx1k51r1jaobjszrcw16gqee57oyrnewfd51s846rxkj96darjn81
```