### PR TITLE
Define account prefixes

### DIFF
--- a/nano/core_test/block.cpp
+++ b/nano/core_test/block.cpp
@@ -463,10 +463,10 @@ TEST (block_builder, from)
 	nano::block_builder builder;
 	auto block = builder
 	             .state ()
-	             .account_address ("xrb_15nhh1kzw3x8ohez6s75wy3jr6dqgq65oaede1fzk5hqxk4j8ehz7iqtb3to")
+	             .account_address ("cat_15nhh1kzw3x8ohez6s75wy3jr6dqgq65oaede1fzk5hqxk4j8ehz7iqtb3to")
 	             .previous_hex ("FEFBCE274E75148AB31FF63EFB3082EF1126BF72BF3FA9C76A97FD5A9F0EBEC5")
 	             .balance_dec ("2251569974100400000000000000000000")
-	             .representative_address ("xrb_1stofnrxuz3cai7ze75o174bpm7scwj9jn3nxsn8ntzg784jf1gzn1jjdkou")
+	             .representative_address ("cat_1stofnrxuz3cai7ze75o174bpm7scwj9jn3nxsn8ntzg784jf1gzn1jjdkou")
 	             .link_hex ("E16DD58C1EFA8B521545B0A74375AA994D9FC43828A4266D75ECF57F07A7EE86")
 	             .build (ec);
 	ASSERT_EQ (block->hash ().to_string (), "2D243F8F92CDD0AD94A1D456A6B15F3BE7A6FCBD98D4C5831D06D15C818CD81F");
@@ -496,10 +496,10 @@ TEST (block_builder, state)
 	nano::block_builder builder;
 	auto block = builder
 	             .state ()
-	             .account_address ("xrb_15nhh1kzw3x8ohez6s75wy3jr6dqgq65oaede1fzk5hqxk4j8ehz7iqtb3to")
+	             .account_address ("cat_15nhh1kzw3x8ohez6s75wy3jr6dqgq65oaede1fzk5hqxk4j8ehz7iqtb3to")
 	             .previous_hex ("FEFBCE274E75148AB31FF63EFB3082EF1126BF72BF3FA9C76A97FD5A9F0EBEC5")
 	             .balance_dec ("2251569974100400000000000000000000")
-	             .representative_address ("xrb_1stofnrxuz3cai7ze75o174bpm7scwj9jn3nxsn8ntzg784jf1gzn1jjdkou")
+	             .representative_address ("cat_1stofnrxuz3cai7ze75o174bpm7scwj9jn3nxsn8ntzg784jf1gzn1jjdkou")
 	             .link_hex ("E16DD58C1EFA8B521545B0A74375AA994D9FC43828A4266D75ECF57F07A7EE86")
 	             .build (ec);
 	ASSERT_EQ (block->hash ().to_string (), "2D243F8F92CDD0AD94A1D456A6B15F3BE7A6FCBD98D4C5831D06D15C818CD81F");
@@ -512,7 +512,7 @@ TEST (block_builder, state_missing_rep)
 	nano::block_builder builder;
 	auto block = builder
 	             .state ()
-	             .account_address ("xrb_15nhh1kzw3x8ohez6s75wy3jr6dqgq65oaede1fzk5hqxk4j8ehz7iqtb3to")
+	             .account_address ("cat_15nhh1kzw3x8ohez6s75wy3jr6dqgq65oaede1fzk5hqxk4j8ehz7iqtb3to")
 	             .previous_hex ("FEFBCE274E75148AB31FF63EFB3082EF1126BF72BF3FA9C76A97FD5A9F0EBEC5")
 	             .balance_dec ("2251569974100400000000000000000000")
 	             .link_hex ("E16DD58C1EFA8B521545B0A74375AA994D9FC43828A4266D75ECF57F07A7EE86")
@@ -557,7 +557,7 @@ TEST (block_builder, state_errors)
 	builder.state ().account_hex ("xrb_bad").build (ec);
 	ASSERT_EQ (ec, nano::error_common::bad_account_number);
 
-	builder.state ().zero ().account_address ("xrb_1111111111111111111111111111111111111111111111111111hifc8npp").build (ec);
+	builder.state ().zero ().account_address ("cat_1111111111111111111111111111111111111111111111111111hifc8npp").build (ec);
 	ASSERT_NO_ERROR (ec);
 }
 
@@ -568,8 +568,8 @@ TEST (block_builder, open)
 	nano::block_builder builder;
 	auto block = builder
 	             .open ()
-	             .account_address ("xrb_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3")
-	             .representative_address ("xrb_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3")
+	             .account_address ("cat_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3")
+	             .representative_address ("cat_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3")
 	             .source_hex ("E89208DD038FBB269987689621D52292AE9C35941A7484756ECCED92A65093BA")
 	             .build (ec);
 	ASSERT_EQ (block->hash ().to_string (), "991CF190094C00F0B68E2E5F75F6BEE95A2E0BD93CEAA4A6734DB9F19B728948");
@@ -605,7 +605,7 @@ TEST (block_builder, change)
 	nano::block_builder builder;
 	auto block = builder
 	             .change ()
-	             .representative_address ("xrb_3rropjiqfxpmrrkooej4qtmm1pueu36f9ghinpho4esfdor8785a455d16nf")
+	             .representative_address ("cat_3rropjiqfxpmrrkooej4qtmm1pueu36f9ghinpho4esfdor8785a455d16nf")
 	             .previous_hex ("088EE46429CA936F76C4EAA20B97F6D33E5D872971433EE0C1311BCB98764456")
 	             .build (ec);
 	ASSERT_EQ (block->hash ().to_string (), "13552AC3928E93B5C6C215F61879358E248D4A5246B8B3D1EEC5A566EDCEE077");
@@ -640,7 +640,7 @@ TEST (block_builder, send)
 	nano::block_builder builder;
 	auto block = builder
 	             .send ()
-	             .destination_address ("xrb_1gys8r4crpxhp94n4uho5cshaho81na6454qni5gu9n53gksoyy1wcd4udyb")
+	             .destination_address ("cat_1gys8r4crpxhp94n4uho5cshaho81na6454qni5gu9n53gksoyy1wcd4udyb")
 	             .previous_hex ("F685856D73A488894F7F3A62BC3A88E17E985F9969629FF3FDD4A0D4FD823F24")
 	             .balance_hex ("00F035A9C7D818E7C34148C524FFFFEE")
 	             .build (ec);

--- a/nano/core_test/uint256_union.cpp
+++ b/nano/core_test/uint256_union.cpp
@@ -368,8 +368,8 @@ TEST (uint256_union, big_endian_union_function)
 TEST (uint256_union, decode_nano_variant)
 {
 	nano::account key;
-	ASSERT_FALSE (key.decode_account ("xrb_1111111111111111111111111111111111111111111111111111hifc8npp"));
-	ASSERT_FALSE (key.decode_account ("nano_1111111111111111111111111111111111111111111111111111hifc8npp"));
+	ASSERT_FALSE (key.decode_account ("cat_1111111111111111111111111111111111111111111111111111hifc8npp"));
+	ASSERT_FALSE (key.decode_account ("meow_1111111111111111111111111111111111111111111111111111hifc8npp"));
 }
 
 TEST (uint256_union, account_transcode)
@@ -383,7 +383,7 @@ TEST (uint256_union, account_transcode)
 	 * Handle different offsets for the underscore separator
 	 * for "xrb_" prefixed and "nano_" prefixed accounts
 	 */
-	unsigned offset = (text.front () == 'x') ? 3 : 4;
+	unsigned offset = (text.front () == 'c') ? 3 : 4;
 	ASSERT_EQ ('_', text[offset]);
 	text[offset] = '-';
 	nano::account value2;
@@ -401,7 +401,7 @@ TEST (uint256_union, account_encode_lex)
 	/*
 	 * Handle different lengths for "xrb_" prefixed and "nano_" prefixed accounts
 	 */
-	unsigned length = (min_text.front () == 'x') ? 64 : 65;
+	unsigned length = (min_text.front () == 'c') ? 64 : 65;
 	ASSERT_EQ (length, min_text.size ());
 	ASSERT_EQ (length, max_text.size ());
 

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -346,7 +346,7 @@ TEST (account, encode_zero)
 	/*
 	 * Handle different lengths for "xrb_" prefixed and "nano_" prefixed accounts
 	 */
-	ASSERT_EQ ((str0.front () == 'x') ? 64 : 65, str0.size ());
+	ASSERT_EQ ((str0.front () == 'c') ? 64 : 65, str0.size ());
 	ASSERT_EQ (65, str0.size ());
 	nano::account number1;
 	ASSERT_FALSE (number1.decode_account (str0));
@@ -363,7 +363,7 @@ TEST (account, encode_all)
 	/*
 	 * Handle different lengths for "xrb_" prefixed and "nano_" prefixed accounts
 	 */
-	ASSERT_EQ ((str0.front () == 'x') ? 64 : 65, str0.size ());
+	ASSERT_EQ ((str0.front () == 'c') ? 64 : 65, str0.size ());
 	nano::account number1;
 	ASSERT_FALSE (number1.decode_account (str0));
 	ASSERT_EQ (number0, number1);

--- a/nano/lib/numbers.cpp
+++ b/nano/lib/numbers.cpp
@@ -75,8 +75,8 @@ bool nano::public_key::decode_account (std::string const & source_a)
 	auto error (source_a.size () < 5);
 	if (!error)
 	{
-		auto xrb_prefix (source_a[0] == 'x' && source_a[1] == 'r' && source_a[2] == 'b' && (source_a[3] == '_' || source_a[3] == '-'));
-		auto nano_prefix (source_a[0] == 'n' && source_a[1] == 'a' && source_a[2] == 'n' && source_a[3] == 'o' && (source_a[4] == '_' || source_a[4] == '-'));
+		auto xrb_prefix (source_a[0] == 'c' && source_a[1] == 'a' && source_a[2] == 't' && (source_a[3] == '_' || source_a[3] == '-'));
+		auto nano_prefix (source_a[0] == 'm' && source_a[1] == 'e' && source_a[2] == 'o' && source_a[3] == 'w' && (source_a[4] == '_' || source_a[4] == '-'));
 		auto node_id_prefix = (source_a[0] == 'n' && source_a[1] == 'o' && source_a[2] == 'd' && source_a[3] == 'e' && source_a[4] == '_');
 		error = (xrb_prefix && source_a.size () != 64) || (nano_prefix && source_a.size () != 65);
 		if (!error)

--- a/nano/lib/numbers.cpp
+++ b/nano/lib/numbers.cpp
@@ -49,7 +49,7 @@ void nano::public_key::encode_account (std::string & destination_a) const
 		number_l >>= 5;
 		destination_a.push_back (account_encode (r));
 	}
-	destination_a.append ("_onan"); // nano_
+	destination_a.append ("_woem"); // meow_
 	std::reverse (destination_a.begin (), destination_a.end ());
 }
 

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -34,8 +34,8 @@ char const * live_public_key_data = "E89208DD038FBB269987689621D52292AE9C35941A7
 char const * test_genesis_data = R"%%%({
 	"type": "open",
 	"source": "B0311EA55708D6A53C75CDBF88300259C6D018522FE3D4D0A242E431F9E8B6D0",
-	"representative": "xrb_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpiij4txtdo",
-	"account": "xrb_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpiij4txtdo",
+	"representative": "cat_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpiij4txtdo",
+	"account": "cat_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpiij4txtdo",
 	"work": "7b42a00ee91d5810",
 	"signature": "ECDA914373A2F0CA1296475BAEE40500A7F0A7AD72A5A80C81D7FAB7F6C802B2CC7DB50F5DD0FB25B2EF11761FA7344A158DD5A700B21BD47DE5BD0F63153A02"
 	})%%%";
@@ -43,8 +43,8 @@ char const * test_genesis_data = R"%%%({
 char const * beta_genesis_data = R"%%%({
 	"type": "open",
 	"source": "259A4384075F73E19BEE72C0F23C491E30A678FBBD31D55D3982099D3CDA8116",
-	"representative": "nano_1betag41gqumw8fywwp1yay6k9jinswhqhbjtogmm1ibmnyfo1apej3medr3",
-	"account": "nano_1betag41gqumw8fywwp1yay6k9jinswhqhbjtogmm1ibmnyfo1apej3medr3",
+	"representative": "meow_1betag41gqumw8fywwp1yay6k9jinswhqhbjtogmm1ibmnyfo1apej3medr3",
+	"account": "meow_1betag41gqumw8fywwp1yay6k9jinswhqhbjtogmm1ibmnyfo1apej3medr3",
 	"work": "7fa41edc9f5c8049",
 	"signature": "8E771BAC91958B2323A3613ACAAE8A01BB6DD2EA161FA57ADC7223DB37405D0F774B972EEE99D19E2572211E4C2A967E577F36F3DAFA29FAD2BC17911490DA08"
 	})%%%";
@@ -52,8 +52,8 @@ char const * beta_genesis_data = R"%%%({
 char const * live_genesis_data = R"%%%({
 	"type": "open",
 	"source": "E89208DD038FBB269987689621D52292AE9C35941A7484756ECCED92A65093BA",
-	"representative": "xrb_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3",
-	"account": "xrb_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3",
+	"representative": "cat_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3",
+	"account": "cat_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3",
 	"work": "62f05417dd3fb691",
 	"signature": "9F0C933C8ADE004D808EA1985FA746A7E95BA2A38F867640F53EC8F180BDFE9E2C1268DEAD7C2664F356E37ABA362BC58E46DBA03E523A7B5A19E4B6EB12BB02"
 	})%%%";
@@ -113,7 +113,7 @@ burn_account (0)
 
 	nano::link epoch_link_v2;
 	nano::account nano_live_epoch_v2_signer;
-	auto error (nano_live_epoch_v2_signer.decode_account ("nano_3qb6o6i1tkzr6jwr5s7eehfxwg9x6eemitdinbpi7u8bjjwsgqfj4wzser3x"));
+	auto error (nano_live_epoch_v2_signer.decode_account ("meow_3qb6o6i1tkzr6jwr5s7eehfxwg9x6eemitdinbpi7u8bjjwsgqfj4wzser3x"));
 	debug_assert (!error);
 	auto epoch_v2_signer (network_a == nano::nano_networks::nano_test_network ? nano_test_account : network_a == nano::nano_networks::nano_beta_network ? nano_beta_account : nano_live_epoch_v2_signer);
 	const char * epoch_message_v2 ("epoch v2 block");


### PR DESCRIPTION
### Account prefixes defined.

Account prefixes defined to match the naming convention.
Account prefixes are the part of the address coming before _ in the address and is determining the coin identifier.
It is not really essential for the functionality and can be defined as anything.
It's more of an identifier to an end user to know whet coin is questioned address associated with.

Additionally, genesis blocks are renamed as well in this step since it was essential for a proper build.

**Defined account prefixes:**

```bash
cat_
```
And
```bash
meow_
```

Defined prefixes can be interchangeably used and are completely the same and point to the same account.
The prefixes are also network universal, and are not tied to any specific network type.
They are universally used across all the networks.