### PR TITLE
Define RPC commands for unit conversion

### DIFF
--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -98,27 +98,27 @@ void nano::json_handler::process_request (bool unsafe_a)
 				request.put ("head", request.get<std::string> ("hash"));
 				account_history ();
 			}
-			else if (action == "knano_from_raw" || action == "krai_from_raw")
+			else if (action == "kmeow_from_raw" || action == "kcat_from_raw")
 			{
 				mnano_from_raw (nano::kxrb_ratio);
 			}
-			else if (action == "knano_to_raw" || action == "krai_to_raw")
+			else if (action == "kmeow_to_raw" || action == "kcat_to_raw")
 			{
 				mnano_to_raw (nano::kxrb_ratio);
 			}
-			else if (action == "nano_from_raw" || action == "rai_from_raw")
+			else if (action == "meow_from_raw" || action == "cat_from_raw")
 			{
 				mnano_from_raw (nano::xrb_ratio);
 			}
-			else if (action == "nano_to_raw" || action == "rai_to_raw")
+			else if (action == "meow_to_raw" || action == "cat_to_raw")
 			{
 				mnano_to_raw (nano::xrb_ratio);
 			}
-			else if (action == "mnano_from_raw" || action == "mrai_from_raw")
+			else if (action == "mmeow_from_raw" || action == "mcat_from_raw")
 			{
 				mnano_from_raw ();
 			}
-			else if (action == "mnano_to_raw" || action == "mrai_to_raw")
+			else if (action == "mmeow_to_raw" || action == "mcat_to_raw")
 			{
 				mnano_to_raw ();
 			}

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -3778,7 +3778,7 @@ TEST (rpc, mrai_to_raw)
 	nano::rpc rpc (system.io_ctx, rpc_config, ipc_rpc_processor);
 	rpc.start ();
 	boost::property_tree::ptree request1;
-	request1.put ("action", "mrai_to_raw");
+	request1.put ("action", "mcat_to_raw");
 	request1.put ("amount", "1");
 	test_response response1 (request1, rpc.config.port, system.io_ctx);
 	system.deadline_set (5s);
@@ -3803,7 +3803,7 @@ TEST (rpc, mrai_from_raw)
 	nano::rpc rpc (system.io_ctx, rpc_config, ipc_rpc_processor);
 	rpc.start ();
 	boost::property_tree::ptree request1;
-	request1.put ("action", "mrai_from_raw");
+	request1.put ("action", "mcat_from_raw");
 	request1.put ("amount", nano::Mxrb_ratio.convert_to<std::string> ());
 	test_response response1 (request1, rpc.config.port, system.io_ctx);
 	system.deadline_set (5s);
@@ -3828,7 +3828,7 @@ TEST (rpc, krai_to_raw)
 	nano::rpc rpc (system.io_ctx, rpc_config, ipc_rpc_processor);
 	rpc.start ();
 	boost::property_tree::ptree request1;
-	request1.put ("action", "krai_to_raw");
+	request1.put ("action", "kcat_to_raw");
 	request1.put ("amount", "1");
 	test_response response1 (request1, rpc.config.port, system.io_ctx);
 	system.deadline_set (5s);
@@ -3853,7 +3853,7 @@ TEST (rpc, krai_from_raw)
 	nano::rpc rpc (system.io_ctx, rpc_config, ipc_rpc_processor);
 	rpc.start ();
 	boost::property_tree::ptree request1;
-	request1.put ("action", "krai_from_raw");
+	request1.put ("action", "kcat_from_raw");
 	request1.put ("amount", nano::kxrb_ratio.convert_to<std::string> ());
 	test_response response1 (request1, rpc.config.port, system.io_ctx);
 	system.deadline_set (5s);
@@ -3878,7 +3878,7 @@ TEST (rpc, nano_to_raw)
 	nano::rpc rpc (system.io_ctx, rpc_config, ipc_rpc_processor);
 	rpc.start ();
 	boost::property_tree::ptree request1;
-	request1.put ("action", "nano_to_raw");
+	request1.put ("action", "meow_to_raw");
 	request1.put ("amount", "1");
 	test_response response1 (request1, rpc.config.port, system.io_ctx);
 	system.deadline_set (5s);
@@ -3903,7 +3903,7 @@ TEST (rpc, nano_from_raw)
 	nano::rpc rpc (system.io_ctx, rpc_config, ipc_rpc_processor);
 	rpc.start ();
 	boost::property_tree::ptree request1;
-	request1.put ("action", "nano_from_raw");
+	request1.put ("action", "meow_from_raw");
 	request1.put ("amount", nano::xrb_ratio.convert_to<std::string> ());
 	test_response response1 (request1, rpc.config.port, system.io_ctx);
 	system.deadline_set (5s);


### PR DESCRIPTION
### Unit conversion commands are defined.

RPC commands are used for fractional conversions of Meow Coin.

**Defined RPC commands:**

- meow_to_raw or cat_to_raw
- kmeow_to_raw or kcat_to_raw
- mmeow_to_raw or mcat_to_raw

Commands are interchangeably usable across all the networks.

**Conversion ratios are as follows:**

- 1 meow = 1000000000000000000000000 raw
- 1 kmeow = 1000000000000000000000000000 raw
- 1 mmeow = 1000000000000000000000000000000 raw